### PR TITLE
Zircon resnet18 perf opt

### DIFF
--- a/archipelago/compress_design_packed.py
+++ b/archipelago/compress_design_packed.py
@@ -91,7 +91,7 @@ def build_and_collapse_graph(filename: str) -> pydot.Dot:
 
             reg_count = len(regs_seen)
             collapsed_name = f"r{collapsed_counter}"
-            collapsed_type = f"{reg_count} regs"
+            collapsed_type = f"{reg_count} fifos"
             collapsed_counter += 1
 
             add_node(collapsed_name, collapsed_type)

--- a/archipelago/compress_design_packed.py
+++ b/archipelago/compress_design_packed.py
@@ -1,0 +1,154 @@
+import re
+import pydot
+from collections import defaultdict
+
+def build_and_collapse_graph(filename: str) -> pydot.Dot:
+    """
+    Read the edge file, build a pydot digraph, and collapse chains of nodes
+    whose names start with 'r'. Collapsed regs are replaced by nodes named
+    (rX, N regs), where X is a unique ID and N is the number of regs collapsed.
+    """
+
+    edges = []           # (src_name, src_type, dst_name, dst_type, edge_label)
+    node_types = {}      # name -> type
+
+    def parse_node(inner: str):
+        parts = [p.strip() for p in inner.split(",", 1)]
+        if len(parts) == 2:
+            return parts[0], parts[1]
+        return inner.strip(), "unknown"
+
+    # --- Parse file into edges and node types ---
+    with open(filename, "r") as fh:
+        for raw in fh:
+            line = raw.strip()
+            if not line:
+                continue
+            edge_name = line.split(":", 1)[0].strip()
+            groups = re.findall(r"\(([^)]+)\)", line)
+            if not groups:
+                continue
+            src_name, src_type = parse_node(groups[0])
+            node_types[src_name] = src_type
+            for g in groups[1:]:
+                dst_name, dst_type = parse_node(g)
+                node_types[dst_name] = dst_type
+                edges.append((src_name, src_type, dst_name, dst_type, edge_name))
+
+    # --- Build adjacency ---
+    succs = defaultdict(list)
+    for sname, stype, dname, dtype, lbl in edges:
+        succs[sname].append((dname, lbl))
+
+    def is_reg(name: str) -> bool:
+        return name.startswith("r")
+
+    # --- Build simplified graph ---
+    new_graph = pydot.Dot(graph_type="digraph")
+    added_nodes = set()
+    added_edges = set()
+    collapsed_counter = 0  # for unique reg node names
+
+    node_types_new = {}  # track new node types
+
+    def add_node(name: str, ntype: str):
+        if name not in added_nodes:
+            new_graph.add_node(pydot.Node(name, label=f"({name}, {ntype})"))
+            added_nodes.add(name)
+            node_types_new[name] = ntype
+
+    for src in list(succs.keys()):
+        if is_reg(src):
+            continue  # skip registers as starting points
+
+        add_node(src, node_types.get(src, "unknown"))
+
+        for dst, edge_label in succs[src]:
+            if not is_reg(dst):
+                add_node(dst, node_types.get(dst, "unknown"))
+                key = (src, dst, edge_label)
+                if key not in added_edges:
+                    new_graph.add_edge(pydot.Edge(src, dst, label=edge_label))
+                    added_edges.add(key)
+                continue
+
+            # collapse chain of regs starting at dst
+            regs_seen = set()
+            endpoints = set()
+            stack = [dst]
+            while stack:
+                cur = stack.pop()
+                if cur in regs_seen:
+                    continue
+                if not is_reg(cur):
+                    continue
+                regs_seen.add(cur)
+                for succ, _ in succs.get(cur, []):
+                    if is_reg(succ):
+                        stack.append(succ)
+                    else:
+                        endpoints.add(succ)
+
+            reg_count = len(regs_seen)
+            collapsed_name = f"r{collapsed_counter}"
+            collapsed_type = f"{reg_count} regs"
+            collapsed_counter += 1
+
+            add_node(collapsed_name, collapsed_type)
+
+            # edge src -> collapsed
+            key_in = (src, collapsed_name, edge_label)
+            if key_in not in added_edges:
+                new_graph.add_edge(pydot.Edge(src, collapsed_name, label=edge_label))
+                added_edges.add(key_in)
+
+            # edges collapsed -> endpoints
+            for end in endpoints:
+                if is_reg(end):
+                    continue
+                add_node(end, node_types.get(end, "unknown"))
+                key_out = (collapsed_name, end, None)
+                if key_out not in added_edges:
+                    new_graph.add_edge(pydot.Edge(collapsed_name, end))
+                    added_edges.add(key_out)
+
+    # attach node_types_new to graph object for later use
+    new_graph.node_types_new = node_types_new
+    return new_graph
+
+
+def export_graph_to_file(graph: pydot.Dot, outfile: str):
+    """
+    Export the simplified graph to a text file in the same format as input.
+    """
+    node_types = graph.node_types_new
+    lines = []
+    edge_id = 1
+
+    for edge in graph.get_edges():
+        src = edge.get_source()
+        dst = edge.get_destination()
+        src_type = node_types.get(src, "unknown")
+        dst_type = node_types.get(dst, "unknown")
+        lbl = edge.get_label()
+        if lbl:
+            line = f"e{edge_id}: ({src}, {src_type})\t({dst}, {dst_type})"
+        else:
+            line = f"e{edge_id}: ({src}, {src_type})\t({dst}, {dst_type})"
+        lines.append(line)
+        edge_id += 1
+
+    with open(outfile, "w") as fh:
+        fh.write("Netlists:\n")
+        fh.write("\n".join(lines))
+        fh.write("\n")
+
+
+# Example usage
+if __name__ == "__main__":
+    packed_filename = "/aha/Halide-to-Hardware/apps/hardware_benchmarks/apps/zircon_residual_relu_fp/bin/design_post_pipe.packed"
+    g = build_and_collapse_graph(packed_filename)
+    output_filename = "/aha/Halide-to-Hardware/apps/hardware_benchmarks/apps/zircon_residual_relu_fp/bin/design_post_pipe_compressed.packed"
+    export_graph_to_file(g, output_filename)
+    print(f"Compressed graph exported to {output_filename}")
+    print("\033[93mNOTE: The compression script currently assumes there are no branches from regs in the compute graph. This assumption may not hold in all cases.\033[0m")

--- a/archipelago/io.py
+++ b/archipelago/io.py
@@ -142,7 +142,12 @@ def _generate_visualization_from_packed(packed_file, output_basename, label_edge
             source, source_port = [x.strip() for x in src_full.split(",")]
 
             # Ensure the source node is drawn
-            graph.node(source, color=colors.get(source[0], "black"))
+            if 'regs' in source_port:
+                source_label = source_port
+                graph.node(source, color=colors.get(source[0], "black"), label=source_label)
+            else:
+                graph.node(source, color=colors.get(source[0], "black"))
+            # breakpoint()
 
             # The rest are destinations, if any
             dest_parts = remainder.split("\t")[1:]
@@ -150,7 +155,11 @@ def _generate_visualization_from_packed(packed_file, output_basename, label_edge
                 dest_full = dest_part.strip("()\n")
                 dest, dest_port = [x.strip() for x in dest_full.split(",")]
                 # Ensure the destination node is drawn
-                graph.node(dest, color=colors.get(dest[0], "black"))
+                if 'regs' in dest_port:
+                    dest_label = dest_port
+                    graph.node(dest, color=colors.get(dest[0], "black"), label=dest_label)
+                else:
+                    graph.node(dest, color=colors.get(dest[0], "black"))
 
                 if label_edges:
                     graph.edge(source, dest, label=f"{source_port}->{dest_port}")
@@ -454,3 +463,9 @@ def generate_packed_from_place_and_route(cwd, place_file, route_file, new_packed
         _generate_visualization_from_packed(new_packed_file, cwd + "/design_packed_post_pipe")
 
 
+
+if __name__ == "__main__":
+    packed_filename = "/aha/design_post_pipe_compressed.packed"
+    output_base_name = "/aha/design_packed_compressed"
+    print(f"Generating visualization from {packed_filename}. The result is placed at {output_base_name}.pdf")
+    _generate_visualization_from_packed(packed_filename, output_base_name)

--- a/archipelago/io.py
+++ b/archipelago/io.py
@@ -142,7 +142,7 @@ def _generate_visualization_from_packed(packed_file, output_basename, label_edge
             source, source_port = [x.strip() for x in src_full.split(",")]
 
             # Ensure the source node is drawn
-            if 'regs' in source_port:
+            if 'fifos' in source_port:
                 source_label = source_port
                 graph.node(source, color=colors.get(source[0], "black"), label=source_label)
             else:
@@ -155,7 +155,7 @@ def _generate_visualization_from_packed(packed_file, output_basename, label_edge
                 dest_full = dest_part.strip("()\n")
                 dest, dest_port = [x.strip() for x in dest_full.split(",")]
                 # Ensure the destination node is drawn
-                if 'regs' in dest_port:
+                if 'fifos' in dest_port:
                     dest_label = dest_port
                     graph.node(dest, color=colors.get(dest[0], "black"), label=dest_label)
                 else:
@@ -465,7 +465,7 @@ def generate_packed_from_place_and_route(cwd, place_file, route_file, new_packed
 
 
 if __name__ == "__main__":
-    packed_filename = "/aha/design_post_pipe_compressed.packed"
-    output_base_name = "/aha/design_packed_compressed"
+    packed_filename = "/aha/Halide-to-Hardware/apps/hardware_benchmarks/apps/zircon_residual_relu_fp/bin/design_post_pipe_compressed.packed"
+    output_base_name = "/aha/Halide-to-Hardware/apps/hardware_benchmarks/apps/zircon_residual_relu_fp/bin/design_post_pipe_compressed"
     print(f"Generating visualization from {packed_filename}. The result is placed at {output_base_name}.pdf")
     _generate_visualization_from_packed(packed_filename, output_base_name)

--- a/archipelago/pipeline.py
+++ b/archipelago/pipeline.py
@@ -769,8 +769,9 @@ def update_kernel_latencies(
     pipeline_config_interval,
     pes_with_packed_ponds,
     sparse,
+    dense_ready_valid=False,
 ):
-    if sparse:
+    if sparse or dense_ready_valid:
         return
 
     port_remap = json.load(open(f"{dir_name}/design.port_remap"))
@@ -926,6 +927,7 @@ def pipeline_pnr(
     pes_with_packed_ponds,
     sparse,
     west_in_io_sides,
+    dense_ready_valid=False,
 ):
     if load_only:
         packed_file = os.path.join(app_dir, "design.packed")
@@ -937,7 +939,7 @@ def pipeline_pnr(
     id_to_name_save = copy.deepcopy(id_to_name)
 
     existing_kernel_latencies = {}
-    if not sparse:
+    if not (sparse or dense_ready_valid):
         kernel_latencies_file = glob.glob(f"{app_dir}/*_compute_kernel_latencies.json")[0]
         existing_kernel_latencies = json.load(open(kernel_latencies_file, "r"))
 
@@ -982,6 +984,7 @@ def pipeline_pnr(
         pipeline_config_interval,
         pes_with_packed_ponds,
         sparse,
+        dense_ready_valid=dense_ready_valid,
     )
 
     if "POST_PNR_ITR" in os.environ:
@@ -1009,6 +1012,7 @@ def pipeline_pnr(
                     pipeline_config_interval,
                     pes_with_packed_ponds,
                     sparse,
+                    dense_ready_valid=dense_ready_valid,
                 )
 
                 print("\nIteration", itr + 1, "frequency")
@@ -1047,6 +1051,7 @@ def pipeline_pnr(
             pipeline_config_interval,
             pes_with_packed_ponds,
             sparse,
+            dense_ready_valid=dense_ready_valid,
         )
 
         for _ in range(max_itr):
@@ -1065,6 +1070,7 @@ def pipeline_pnr(
             pipeline_config_interval,
             pes_with_packed_ponds,
             sparse,
+            dense_ready_valid=dense_ready_valid,
         )
         print("\nFinal application frequency:")
         curr_freq, crit_path, crit_nets = sta(graph, west_in_io_sides)
@@ -1091,5 +1097,13 @@ def pipeline_pnr(
 
     dump_routing_result(app_dir, routing)
     dump_placement_result(app_dir, placement, id_to_name)
+    dump_id_to_name(app_dir, id_to_name)
 
     return placement, routing, id_to_name
+
+
+if __name__ == "__main__":
+    app_dir = "/aha/Halide-to-Hardware/apps/hardware_benchmarks/apps/zircon_residual_relu_fp/bin/"
+    packed_file = os.path.join(app_dir, "design.packed")
+    id_to_name = pythunder.io.load_id_to_name(packed_file)
+    dump_id_to_name(app_dir, id_to_name)

--- a/archipelago/pipeline.py
+++ b/archipelago/pipeline.py
@@ -40,13 +40,15 @@ def find_break_idx(graph, crit_path):
     if len(crit_path) < 2:
         raise ValueError("Can't find available register on critical path")
 
-    if graph.sparse and len(crit_path) < 5:
+    # if graph.sparse and len(crit_path) < 5:
+    if graph.split_fifos and len(crit_path) < 5:
         raise ValueError("Can't find available FIFO on critical path")
 
     min_path = crit_path[-1][1]
     min_idx = -1
 
-    if graph.sparse:
+    # if graph.sparse:
+    if graph.split_fifos:
         for idx, node in enumerate(crit_path[:-4]):
             if (
                 isinstance(crit_path[idx][0], RouteNode)
@@ -143,7 +145,8 @@ def break_crit_path(graph, id_to_name, crit_path, placement, routes):
     graph.update_sources_and_sinks()
     graph.update_edge_kernels()
 
-    if graph.sparse:
+    # if graph.sparse:
+    if graph.split_fifos:
         break_idx += 3
         break_node_source = crit_path[break_idx][0]
         break_node_dest = graph.sinks[break_node_source][0]
@@ -247,7 +250,8 @@ def exhaustive_pipe(graph, id_to_name, placement, routing):
                     curr_node = graph.sinks[curr_node][0]
 
                 for idx in range(len(path)):
-                    if graph.sparse:
+                    # if graph.sparse:
+                    if graph.split_fifos:
                         if idx + 4 >= len(path):
                             break
                         if (
@@ -962,6 +966,7 @@ def pipeline_pnr(
         pond_latency=0,
         io_latency=io_cycles,
         sparse=sparse,
+        dense_ready_valid=dense_ready_valid,
     )
 
     # Update placement dict

--- a/archipelago/pnr_.py
+++ b/archipelago/pnr_.py
@@ -38,6 +38,7 @@ def pnr(
     pipeline_config_interval=0,
     pes_with_packed_ponds=None,
     sparse=False,
+    dense_ready_valid=False,
     west_in_io_sides=False,
 ):
     if input_netlist is None and len(packed_file):
@@ -193,6 +194,7 @@ def pnr(
                         pes_with_packed_ponds,
                         sparse,
                         west_in_io_sides,
+                        dense_ready_valid=dense_ready_valid,
                     )
                     freq = run_sta(
                         packed_file,
@@ -305,6 +307,7 @@ def pnr(
             pes_with_packed_ponds,
             sparse,
             west_in_io_sides,
+            dense_ready_valid=dense_ready_valid,
         )
         packed_file = dump_packed_result(
             app_name, cwd, input_netlist, id_to_name, copy_to_dir=copy_to_dir

--- a/archipelago/pnr_graph.py
+++ b/archipelago/pnr_graph.py
@@ -313,7 +313,7 @@ class RoutingResultGraph:
                     if node not in visited:
                         queue.append(node)
                         visited.append(node)
-        
+
         for node in kernel_nodes:
             if len(self.sources[node]) == 0:
                 kernel_input_nodes.append(node)
@@ -827,10 +827,14 @@ def construct_graph(
     pond_latency=0,
     io_latency=0,
     sparse=False,
+    dense_ready_valid=False,
 ):
     graph = RoutingResultGraph()
     graph.id_to_name = id_to_name
     graph.sparse = sparse
+    graph.dense_ready_valid = dense_ready_valid
+    use_non_split_fifos = "USE_NON_SPLIT_FIFOS" in os.environ and os.environ.get("USE_NON_SPLIT_FIFOS") == "1"
+    graph.split_fifos = not(use_non_split_fifos) and (dense_ready_valid or sparse)
     graph.gen_placement(placement, netlist)
 
     max_reg_id = 0

--- a/archipelago/visualize.py
+++ b/archipelago/visualize.py
@@ -530,10 +530,10 @@ def find_last_sb(routing_result_graph, node):
 
     curr_node = node
     while not found_sb and not found_port:
-        assert len(routing_result_graph.sources[curr_node]) == 1, (
-            curr_node,
-            routing_result_graph.sources[curr_node],
-        )
+        # assert len(routing_result_graph.sources[curr_node]) == 1, (
+        #     curr_node,
+        #     routing_result_graph.sources[curr_node],
+        # )
 
         source = routing_result_graph.sources[curr_node][0]
 


### PR DESCRIPTION
- Introduce script to count FIFOs on a path, to help with path balancing. Note that this script is not guaranteed to work if there are branches from the FIFOs in the graph
- In pipelining scripts, eliminate assumption that sparse and dense ready valid apps use splitFIFO design. Previously, this would force the pipelining tool to place an even number of regs on all paths (unnecessary if non-SplitFIFOs are used). 

Corresponding AHA PR: https://github.com/StanfordAHA/aha/pull/2086